### PR TITLE
[Date] Refactor date related traits to mockable and immutable datetime

### DIFF
--- a/src/Model/ArchivableTrait.php
+++ b/src/Model/ArchivableTrait.php
@@ -4,9 +4,11 @@ declare(strict_types=1);
 
 namespace Symandy\Component\Resource\Model;
 
-use DateTime;
+use DateTimeImmutable;
 use DateTimeInterface;
 use Doctrine\ORM\Mapping\Column;
+
+use function time;
 
 trait ArchivableTrait
 {
@@ -26,7 +28,7 @@ trait ArchivableTrait
 
     public function archive(): void
     {
-        $this->setArchivedAt(new DateTime());
+        $this->setArchivedAt(DateTimeImmutable::createFromFormat('U', (string) time()));
     }
 
     public function restore(): void

--- a/src/Model/CreatableTrait.php
+++ b/src/Model/CreatableTrait.php
@@ -4,9 +4,11 @@ declare(strict_types=1);
 
 namespace Symandy\Component\Resource\Model;
 
-use DateTime;
+use DateTimeImmutable;
 use DateTimeInterface;
 use Doctrine\ORM\Mapping\Column;
+
+use function time;
 
 trait CreatableTrait
 {
@@ -26,7 +28,7 @@ trait CreatableTrait
 
     public function create(): void
     {
-        $this->setCreatedAt(new DateTime());
+        $this->setCreatedAt(DateTimeImmutable::createFromFormat('U', (string) time()));
     }
 
 }

--- a/src/Model/UpdatableTrait.php
+++ b/src/Model/UpdatableTrait.php
@@ -4,9 +4,11 @@ declare(strict_types=1);
 
 namespace Symandy\Component\Resource\Model;
 
-use DateTime;
+use DateTimeImmutable;
 use DateTimeInterface;
 use Doctrine\ORM\Mapping\Column;
+
+use function time;
 
 trait UpdatableTrait
 {
@@ -26,7 +28,7 @@ trait UpdatableTrait
 
     public function update(): void
     {
-        $this->setUpdatedAt(new DateTime());
+        $this->setUpdatedAt(DateTimeImmutable::createFromFormat('U', (string) time()));
     }
 
 }


### PR DESCRIPTION
## Description
Refactor functions that set the current datetime to any property as it was not mockable.
For example `symfony/phpunit-bridge` add a `MockClock` class that mock a lot of php date related function (like `\time()`) but not compatible with `new \DateTime()`.